### PR TITLE
Rename deregistered_on to deregistered_at

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: c5d8bc748620d163f4426ac1d0b2ae06426cdc50
+  revision: 3aec520dc18f5a3416135a4c4c4739ed30a35203
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)

--- a/app/models/concerns/can_deactivate_exemption.rb
+++ b/app/models/concerns/can_deactivate_exemption.rb
@@ -15,13 +15,13 @@ module CanDeactivateExemption
       event :cease do
         transitions from: :active,
                     to: :ceased,
-                    after: :update_deregistered_on
+                    after: :update_deregistered_at
       end
 
       event :revoke do
         transitions from: :active,
                     to: :revoked,
-                    after: :update_deregistered_on
+                    after: :update_deregistered_at
       end
 
       event :expire do
@@ -31,8 +31,8 @@ module CanDeactivateExemption
     end
 
     # Transition effects
-    def update_deregistered_on
-      self.deregistered_on = Date.today
+    def update_deregistered_at
+      self.deregistered_at = Date.today
       save!
     end
   end

--- a/app/models/waste_exemptions_engine/registration.rb
+++ b/app/models/waste_exemptions_engine/registration.rb
@@ -23,7 +23,7 @@ module WasteExemptionsEngine
 
       return "active" if registration_exemptions.select(&:active?).any?
 
-      sorted_registration_exemptions = registration_exemptions.sort_by { |re| (re.deregistered_on || re.expires_on) }
+      sorted_registration_exemptions = registration_exemptions.sort_by { |re| (re.deregistered_at || re.expires_on) }
       sorted_registration_exemptions.last.state.to_s
     end
   end

--- a/app/presenters/confirmation_letter_presenter.rb
+++ b/app/presenters/confirmation_letter_presenter.rb
@@ -64,7 +64,7 @@ class ConfirmationLetterPresenter < BasePresenter
     display_date = if registration_exemption.state == "active"
                      registration_exemption.expires_on.to_formatted_s(:day_month_year)
                    else
-                     registration_exemption.deregistered_on.to_formatted_s(:day_month_year)
+                     registration_exemption.deregistered_at.to_formatted_s(:day_month_year)
                    end
 
     I18n.t(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190424143344) do
+ActiveRecord::Schema.define(version: 20190522085202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20190424143344) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.text     "deregistration_message"
-    t.date     "deregistered_on"
+    t.date     "deregistered_at"
   end
 
   add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree
@@ -189,7 +189,7 @@ ActiveRecord::Schema.define(version: 20190424143344) do
     t.boolean  "address_finder_error",   default: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
-    t.string   "type"
+    t.string   "type",                                   null: false
   end
 
   add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree

--- a/lib/defra_ruby/exporters/registration_bulk_export_report.rb
+++ b/lib/defra_ruby/exporters/registration_bulk_export_report.rb
@@ -47,7 +47,7 @@ module DefraRuby
         { header: "exemption_status", attribute: "state" },
         { header: "exemption_valid_from_date", attribute: "registered_on" },
         { header: "exemption_expiry_date", attribute: "expires_on" },
-        { header: "exemption_deregister_date", attribute: "deregistered_on" },
+        { header: "exemption_deregister_date", attribute: "deregistered_at" },
         { header: "exemption_deregister_comment", attribute: "deregistration_message" },
         { header: "assistance_type", attribute: "registration.assistance_mode" }
       ].freeze

--- a/spec/factories/registration_exemption.rb
+++ b/spec/factories/registration_exemption.rb
@@ -13,13 +13,13 @@ FactoryBot.define do
     trait :ceased do
       state { "ceased" }
       deregistration_message { "Ceased for reasons" }
-      deregistered_on { Date.today - 1.day }
+      deregistered_at { Date.today - 1.day }
     end
 
     trait :revoked do
       state { "revoked" }
       deregistration_message { "Revoked for reasons" }
-      deregistered_on { Date.today - 1.day }
+      deregistered_at { Date.today - 1.day }
     end
   end
 end

--- a/spec/models/registration_exemption_spec.rb
+++ b/spec/models/registration_exemption_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
     context "when the state is 'active'" do
       before(:each) do
         registration_exemption.state = :active
-        registration_exemption.deregistered_on = nil
+        registration_exemption.deregistered_at = nil
       end
 
       it "can transition to any of the inactive states" do
@@ -67,16 +67,16 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
           end
 
           if deregistration_states.include? transition
-            it "updates the deregistered_on time stamp" do
+            it "updates the deregistered_at time stamp" do
               expect { registration_exemption.send("#{transition}!") }
-                .to change { registration_exemption.deregistered_on }
+                .to change { registration_exemption.deregistered_at }
                 .from(nil)
                 .to(Date.today)
             end
           else
-            it "does not update the deregistered_on time stamp" do
+            it "does not update the deregistered_at time stamp" do
               expect { registration_exemption.send("#{transition}!") }
-                .to_not change { registration_exemption.deregistered_on }
+                .to_not change { registration_exemption.deregistered_at }
                 .from(nil)
             end
           end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe WasteExemptionsEngine::Registration, type: :model do
           reg_exemption = registration_exemptions.shift
           registration_exemptions.each do |re|
             re.revoke!
-            re.deregistered_on = 1.day.ago
+            re.deregistered_at = 1.day.ago
             re.save!
           end
           reg_exemption.cease!

--- a/spec/services/deregistration_service_spec.rb
+++ b/spec/services/deregistration_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DeregistrationService do
               reg_exemption = registration_exemptions.shift
               registration_exemptions.each do |re|
                 re.cease!
-                re.deregistered_on = 1.day.ago
+                re.deregistered_at = 1.day.ago
                 re.deregistration_message = ceased_message
                 re.save!
               end


### PR DESCRIPTION
This is just about keeping things consistent. Where we are recording a timestamp the pattern has been to use `name_of_field_at` rather than `name_of_field_on`.

For example `created_at`, `updated_at`, and `submitted_at`. This change is just about keeping things consistent.

For reference the rename migration is stored in the [waste-exemptions-engine](https://github.com/defra/waste-exemptions-engine) however all functionality related to deregistering is here hence this change.