### PR TITLE
Remove wickedpdf gem and configs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "paper_trail", "~> 10.2.0"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "require-wicked-pdf-correctly"
+    branch: "master"
 
 # Use the Defra Ruby Exporters gem for the EPR and bulk export functionality
 gem "defra_ruby_exporters",

--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,6 @@ gem "kaminari", "~> 1.1"
 # Use Whenever to manage cron tasks
 gem "whenever", "~> 0.10.0"
 
-# Use Wicked PDF for PDF generation
-gem "wicked_pdf", "~> 1.2"
-
 # Used for auditing and version control
 gem "paper_trail", "~> 10.2.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "paper_trail", "~> 10.2.0"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "master"
+    branch: "require-wicked-pdf-correctly"
 
 # Use the Defra Ruby Exporters gem for the EPR and bulk export functionality
 gem "defra_ruby_exporters",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,6 @@ DEPENDENCIES
   webmock (~> 3.5)
   whenever (~> 0.10.0)
   whenever-test (~> 1.0)
-  wicked_pdf (~> 1.2)
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 3aec520dc18f5a3416135a4c4c4739ed30a35203
-  branch: master
+  revision: f470bbff5f9d36ab83086d6f3cd0f2ba830ea876
+  branch: require-wicked-pdf-correctly
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)

--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require "wicked_pdf"
-
-if WasteExemptionsEngine.configuration.use_xvfb_for_wickedpdf
-  WickedPdf.config = {
-    exe_path: WasteExemptionsEngine::Engine.root.join("script", "wkhtmltopdf.sh").to_s
-  }
-end

--- a/script/wkhtmltopdf.sh
+++ b/script/wkhtmltopdf.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Ensure script is executable using `chmod +x wkhtmltopdf.sh`
-xvfb-run -a --server-args="-screen 0, 1024x768x24" /usr/bin/wkhtmltopdf -q $*


### PR DESCRIPTION
part of: https://eaflood.atlassian.net/browse/RUBY-223

The wicked_pdf gem, initializer config and script are already part of the engine code and dependency of this application.
Requiring and installing the gem twice was causing an error generation in the PDF recorded in the ticket above, for which a PDF was generated with wrong content.