### PR TITLE
Fix test fail when run at midnight BST

### DIFF
--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe WasteExemptionsEngine::Registration, type: :model do
           reg_exemption = registration_exemptions.shift
           registration_exemptions.each do |re|
             re.revoke!
-            re.deregistered_at = 1.day.ago
+            re.deregistered_at = 2.day.ago
             re.save!
           end
           reg_exemption.cease!


### PR DESCRIPTION
It's late. We're into the first dark minutes of a fresh new day but my body is haggard from the last. The screen before me is starting to blur and my bones are pleading for respite and the embrace of sleep, but I push on.

One last push. Only one more, then I'm done.

Muted orange circles, the wheel spins and then the gatekeeper awakens. Arcane letters spill out in jumps and starts but its the dots, the little green dots.

We expect them too, assume they will appear, one hand resting on the lid and our soul two steps already to bed.

...........F......

NO!!!!! How can this be. Our efforts were small and inconsequential. They did little, yet they are rejected. It's broken. YOU have broken something. You are not done.

---

I have spotted a test that can be made to fail if run at a specific time, specifically in the midnight hour during BST. It is related to registrations which have had all their exemptions deregistered. In this case we can no longer display them as ACTIVE, so there is logic to use the state of the last deregistered exemption instead.

The test set up is to create a registration with multiple exemptions, revoke all but one of them setting the deregistered date to 1 day ago, and then to cease the last of them. The test then expects the state of the registration to be "CEASED".

If run at 23:30 UTC during BST however the result is to both revoke and cease the registration on the same date, which means `Registration.state` returns `"revoked"` rather than `"ceased"`.

You can replicate the scenario by using [Timecop](https://github.com/travisjeffery/timecop) to freeze time at the hour in question.

```ruby
context "and none of the exemption registrations are active" do
  before { Timecop.freeze(Time.gm(2019,5,23,23,30,0).in_time_zone("London")) }

  let(:registration) do
    registration = create(:registration)
    registration_exemptions = registration.registration_exemptions.to_a
    reg_exemption = registration_exemptions.shift
    registration_exemptions.each do |re|
      re.revoke!
      re.deregistered_at = 1.days.ago
      re.save!
    end
    reg_exemption.cease!
    registration
  end

  it "returns the state of the exemption registration that has changed state most recently" do
    expect(registration.state).to eq "ceased"
  end

  after { Timecop.return }
end
```

To avoid anyone else falling foul of the issue this change amends the test to revoke the exemptions 2 days ago, which means there is always a days difference between the revoked and ceased exemptions.