### PR TITLE
Save session token change to database

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ActiveRecord::Base
   end
 
   def invalidate_all_sessions!
-    self.session_token = SecureRandom.hex
+    update_attributes(session_token: SecureRandom.hex)
   end
 
   # Validations

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Sessions", type: :request do
       it "updates the session_token" do
         old_session_token = user.session_token
         get destroy_user_session_path
-        expect(user.session_token).to_not eq(old_session_token)
+        expect(user.reload.session_token).to_not eq(old_session_token)
       end
 
       context "when the user is inactive" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-359

This is a security fix designed to block users from being able to reuse cookies after they have signed out.