### PR TITLE
Fix WEX data exports

### DIFF
--- a/config/initializers/defra_ruby_exporters.rb
+++ b/config/initializers/defra_ruby_exporters.rb
@@ -3,6 +3,8 @@
 require "aws-sdk-s3"
 require "defra_ruby/exporters"
 require_relative "../../lib/defra_ruby/exporters/bulk_export_file"
+require_relative "../../lib/defra_ruby/exporters/registration_bulk_export_report"
+require_relative "../../lib/defra_ruby/exporters/registration_epr_export_report"
 
 DefraRuby::Exporters.configure do |c|
   def raise_missing_env_var(variable)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-380

Looks like the reported issue has to deal with the fact that the override classes files were not required in the initializer.
The dummy data created by testing it on the server were generating records for the entire year due to https://github.com/DEFRA/defra-ruby-exporters/blob/master/lib/defra_ruby/exporters/registration_bulk_export_report.rb#L16.

This fixes the issue. Steps forward are for DEV to come together and discuss what to do with this gem.
Eventually, we want an error to be raised if the application using the gem is missing such important files that belongs to the app itself.
Also, this gem is not an engine, and using the strategy of opening the class and re-write the method for it to work doesn't look the best option for me. 