### PR TITLE
Update to include site address area

### DIFF
--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -113,3 +113,12 @@
     <%= address.country_iso %>
   </p>
 <% end %>
+
+<% if address.area.present? %>
+  <h3 class="heading-small">
+    <%= t(".labels.area") %>
+  </h3>
+  <p>
+    <%= address.area %>
+  </p>
+<% end %>

--- a/config/locales/partials/resource_address.en.yml
+++ b/config/locales/partials/resource_address.en.yml
@@ -17,3 +17,4 @@ en:
         logical_status_code: "Logical status code"
         source_data_type: "Source data type"
         country_iso: "Country ISO"
+        area: "Area"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190522085202) do
+ActiveRecord::Schema.define(version: 20190603215354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20190522085202) do
     t.integer  "registration_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
+    t.string   "area"
   end
 
   add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
@@ -132,6 +133,7 @@ ActiveRecord::Schema.define(version: 20190522085202) do
     t.integer  "transient_registration_id"
     t.datetime "created_at",                            null: false
     t.datetime "updated_at",                            null: false
+    t.string   "area"
   end
 
   add_index "transient_addresses", ["transient_registration_id"], name: "index_transient_addresses_on_transient_registration_id", using: :btree


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-25

The existing service has the ability to lookup the EA admin area for a site using the easting and northing values. This is currently out of action whilst we await a fix (the external service we call changed supplier and we have been awaiting support for what the new query should be).

However it has been spotted in our work on migrating the old data to the new schema that we don't have a field for this. So on the basis we want to retain this data, and that we expect to implement the lookup feature in the new service once the issue is resolved, this change adds update the WEX engine to bring in a version that adds `area` to the **address** and **transient_address** models.

It will also update the registration details view to include this information.