### PR TITLE
Implement Aws bucket load of report bulk CSV files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,10 +60,15 @@ gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
     branch: "master"
 
+# Use the Defra Ruby Aws gem for loading files to AWS buckets
+gem "defra-ruby-aws",
+    git: "https://github.com/DEFRA/defra-ruby-aws",
+    branch: "add-end-to-end-test-coverage"
+
 # Use the Defra Ruby Exporters gem for the EPR and bulk export functionality
 gem "defra_ruby_exporters",
     git: "https://github.com/DEFRA/defra-ruby-exporters",
-    branch: "master"
+    branch: "fix-required-class-scope"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc

--- a/Gemfile
+++ b/Gemfile
@@ -63,12 +63,12 @@ gem "waste_exemptions_engine",
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
 gem "defra-ruby-aws",
     git: "https://github.com/DEFRA/defra-ruby-aws",
-    branch: "add-end-to-end-test-coverage"
+    branch: "master"
 
 # Use the Defra Ruby Exporters gem for the EPR and bulk export functionality
 gem "defra_ruby_exporters",
     git: "https://github.com/DEFRA/defra-ruby-exporters",
-    branch: "fix-required-class-scope"
+    branch: "master"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 0.4.0", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-aws
-  revision: 94b8b9d93d4fa18349feb87cf9a5a935715e5e7d
-  branch: add-end-to-end-test-coverage
+  revision: dde43428f2825dc54c47236469105094beff1352
+  branch: master
   specs:
     defra-ruby-aws (0.0.1)
       aws-sdk-s3
 
 GIT
   remote: https://github.com/DEFRA/defra-ruby-exporters
-  revision: 462c4609e884d9c7898234ddd66c394a14f58d1c
-  branch: fix-required-class-scope
+  revision: 224a953df1a7a0ed1523731d09f17871fc572813
+  branch: master
   specs:
     defra_ruby_exporters (0.0.1)
       activesupport
@@ -83,8 +83,8 @@ GEM
     arel (6.0.4)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.165.0)
-    aws-sdk-core (3.53.0)
+    aws-partitions (1.172.0)
+    aws-sdk-core (3.54.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -92,10 +92,10 @@ GEM
     aws-sdk-kms (1.21.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.40.0)
+    aws-sdk-s3 (1.42.0)
       aws-sdk-core (~> 3, >= 3.53.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,15 @@
 GIT
+  remote: https://github.com/DEFRA/defra-ruby-aws
+  revision: 94b8b9d93d4fa18349feb87cf9a5a935715e5e7d
+  branch: add-end-to-end-test-coverage
+  specs:
+    defra-ruby-aws (0.0.1)
+      aws-sdk-s3
+
+GIT
   remote: https://github.com/DEFRA/defra-ruby-exporters
-  revision: 3ef183e78f54ebd34002a7f08393c5ac02b137b1
-  branch: master
+  revision: 462c4609e884d9c7898234ddd66c394a14f58d1c
+  branch: fix-required-class-scope
   specs:
     defra_ruby_exporters (0.0.1)
       activesupport
@@ -378,6 +386,7 @@ DEPENDENCIES
   bullet (~> 5.9)
   cancancan (~> 2.0)
   database_cleaner
+  defra-ruby-aws!
   defra_ruby_exporters!
   defra_ruby_style
   devise (>= 4.4.3)

--- a/app/services/reports/monthly_bulk_report_service.rb
+++ b/app/services/reports/monthly_bulk_report_service.rb
@@ -56,7 +56,7 @@ module Reports
     end
 
     def bucket_name
-      ENV["AWS_BULK_EXPORT_BUCKET"]
+      WasteExemptionsBackOffice::Application.config.bulk_reports_bucket_name
     end
   end
 end

--- a/app/services/reports/monthly_bulk_report_service.rb
+++ b/app/services/reports/monthly_bulk_report_service.rb
@@ -5,27 +5,24 @@ module Reports
     def run(first_day_of_the_month)
       @first_day_of_the_month = first_day_of_the_month
 
-      # Generate report
-      temp_file.write(bulk_report)
+      populate_temp_file
 
-      # upload file to s3
+      load_file_to_aws_bucket
 
-      # rubocop:disable Layout/CommentIndentation
-      # if upload successfull
-        # record content created
-      # else
-        # retry 3 times then exit with failure
-      # end
-      # rubocop:enable Layout/CommentIndentation
+      # record_content_created
     rescue StandardError => e
       Airbrake.notify e, file_name: file_name
-      Rails.logger.error "Generate bulk export csv error for #{file_name}:\n#{error}"
+      Rails.logger.error "Generate bulk export csv error for #{file_name}:\n#{e}"
     ensure
       temp_file.close
       temp_file.unlink
     end
 
     private
+
+    def populate_temp_file
+      temp_file.write(bulk_report)
+    end
 
     def temp_file
       @_temp_file ||= Tempfile.new(file_name)
@@ -40,6 +37,26 @@ module Reports
 
     def bulk_report
       MonthlyBulkSerializer.new(@first_day_of_the_month).to_csv
+    end
+
+    def load_file_to_aws_bucket
+      result = nil
+
+      3.times do
+        result = bucket.load(temp_file)
+
+        break if result.successful?
+      end
+
+      raise(result.error) unless result.successful?
+    end
+
+    def bucket
+      @_bucket ||= DefraRuby::Aws.get_bucket(bucket_name)
+    end
+
+    def bucket_name
+      ENV["AWS_BULK_EXPORT_BUCKET"]
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,9 @@ module WasteExemptionsBackOffice
     config.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
     config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 
+    # AWS monthly bulk export
+    config.bulk_reports_bucket_name = ENV["AWS_BULK_EXPORT_BUCKET"]
+
     config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
 
     # Emails

--- a/config/initializers/defra_ruby_aws.rb
+++ b/config/initializers/defra_ruby_aws.rb
@@ -7,12 +7,16 @@ DefraRuby::Aws.configure do |c|
     raise("Environment variable #{variable} has not been set")
   end
 
+  ENV["AWS_BULK_EXPORT_BUCKET"].present? || raise_missing_env_var("AWS_BULK_EXPORT_BUCKET")
+  ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"].present? || raise_missing_env_var("AWS_BULK_EXPORT_ACCESS_KEY_ID")
+  ENV["AWS_BULK_EXPORT_SECRET_ACCESS_KEY"] || raise_missing_env_var("AWS_BULK_EXPORT_SECRET_ACCESS_KEY")
+
   c.buckets = [{
     name: (ENV["AWS_BULK_EXPORT_BUCKET"] || raise_missing_env_var("AWS_BULK_EXPORT_BUCKET")),
     region: ENV["AWS_REGION"],
     credentials: {
-      access_key_id: (ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"] || raise_missing_env_var("AWS_BULK_EXPORT_ACCESS_KEY_ID")),
-      secret_access_key: (ENV["AWS_BULK_EXPORT_SECRET_ACCESS_KEY"] || raise_missing_env_var("AWS_BULK_EXPORT_SECRET_ACCESS_KEY"))
+      access_key_id: ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"],
+      secret_access_key: ENV["AWS_BULK_EXPORT_SECRET_ACCESS_KEY"]
     }
   }]
 end

--- a/config/initializers/defra_ruby_aws.rb
+++ b/config/initializers/defra_ruby_aws.rb
@@ -3,16 +3,8 @@
 require "defra_ruby/aws"
 
 DefraRuby::Aws.configure do |c|
-  def raise_missing_env_var(variable)
-    raise("Environment variable #{variable} has not been set")
-  end
-
-  ENV["AWS_BULK_EXPORT_BUCKET"].present? || raise_missing_env_var("AWS_BULK_EXPORT_BUCKET")
-  ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"].present? || raise_missing_env_var("AWS_BULK_EXPORT_ACCESS_KEY_ID")
-  ENV["AWS_BULK_EXPORT_SECRET_ACCESS_KEY"] || raise_missing_env_var("AWS_BULK_EXPORT_SECRET_ACCESS_KEY")
-
   c.buckets = [{
-    name: (ENV["AWS_BULK_EXPORT_BUCKET"] || raise_missing_env_var("AWS_BULK_EXPORT_BUCKET")),
+    name: ENV["AWS_BULK_EXPORT_BUCKET"],
     region: ENV["AWS_REGION"],
     credentials: {
       access_key_id: ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"],

--- a/config/initializers/defra_ruby_aws.rb
+++ b/config/initializers/defra_ruby_aws.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "defra_ruby/aws"
+
+DefraRuby::Aws.configure do |c|
+  def raise_missing_env_var(variable)
+    raise("Environment variable #{variable} has not been set")
+  end
+
+  c.buckets = [{
+    name: (ENV["AWS_BULK_EXPORT_BUCKET"] || raise_missing_env_var("AWS_BULK_EXPORT_BUCKET")),
+    region: ENV["AWS_REGION"],
+    credentials: {
+      access_key_id: (ENV["AWS_BULK_EXPORT_ACCESS_KEY_ID"] || raise_missing_env_var("AWS_BULK_EXPORT_ACCESS_KEY_ID")),
+      secret_access_key: (ENV["AWS_BULK_EXPORT_SECRET_ACCESS_KEY"] || raise_missing_env_var("AWS_BULK_EXPORT_SECRET_ACCESS_KEY"))
+    }
+  }]
+end

--- a/spec/factories/registration_exemption.rb
+++ b/spec/factories/registration_exemption.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
       deregistration_message { "Revoked for reasons" }
       deregistered_at { Date.today - 1.day }
     end
+
+    trait :with_registration do
+      registration
+    end
   end
 end

--- a/spec/services/reports/monthly_bulk_report_service_spec.rb
+++ b/spec/services/reports/monthly_bulk_report_service_spec.rb
@@ -11,17 +11,19 @@ module Reports
           stub_successful_request
           create_list(:registration_exemption, 2, :with_registration, registered_on: first_day_of_the_month)
 
-          expect_no_error
+          # Expect no error gets notified
+          expect(Airbrake).to_not receive(:notify)
 
           MonthlyBulkReportService.run(first_day_of_the_month)
         end
       end
 
-      context "when the request succeed" do
+      context "when the request fails" do
         it "fails gracefully and report the error" do
           stub_failing_request
           create_list(:registration_exemption, 2, :with_registration, registered_on: first_day_of_the_month)
 
+          # Expect an error to get notified
           expect(Airbrake).to receive(:notify).once
 
           MonthlyBulkReportService.run(first_day_of_the_month)
@@ -40,10 +42,6 @@ module Reports
       ).to_return(
         status: 403
       )
-    end
-
-    def expect_no_error
-      expect(Airbrake).to_not receive(:notify)
     end
   end
 end

--- a/spec/services/reports/monthly_bulk_report_service_spec.rb
+++ b/spec/services/reports/monthly_bulk_report_service_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 module Reports
   RSpec.describe MonthlyBulkReportService do
     describe ".run" do
-      let(:first_day_of_the_month) { Date.new(2019, 06, 01) }
+      let(:first_day_of_the_month) { Date.new(2019, 6, 1) }
       context "when the request succeed" do
         it "generates a CSV file containing exemptions for the given months and upload it to AWS" do
           stub_successful_request
@@ -30,13 +30,13 @@ module Reports
     end
 
     def stub_successful_request
-      stub_request(:put, /https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+/)
+      stub_request(:put, %r{https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+})
     end
 
     def stub_failing_request
       stub_request(
         :put,
-        /https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+/
+        %r{https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+}
       ).to_return(
         status: 403
       )

--- a/spec/services/reports/monthly_bulk_report_service_spec.rb
+++ b/spec/services/reports/monthly_bulk_report_service_spec.rb
@@ -5,14 +5,45 @@ require "rails_helper"
 module Reports
   RSpec.describe MonthlyBulkReportService do
     describe ".run" do
-      it "generates a CSV file containing exemptions for the given month" do
-        monthly_bulk_serializer = double(:monthly_bulk_serializer)
+      let(:first_day_of_the_month) { Date.new(2019, 06, 01) }
+      context "when the request succeed" do
+        it "generates a CSV file containing exemptions for the given months and upload it to AWS" do
+          stub_successful_request
+          create_list(:registration_exemption, 2, :with_registration, registered_on: first_day_of_the_month)
 
-        expect(MonthlyBulkSerializer).to receive(:new).and_return(monthly_bulk_serializer)
-        expect(monthly_bulk_serializer).to receive(:to_csv)
+          expect_no_error
 
-        MonthlyBulkReportService.run(Date.today)
+          MonthlyBulkReportService.run(first_day_of_the_month)
+        end
       end
+
+      context "when the request succeed" do
+        it "fails gracefully and report the error" do
+          stub_failing_request
+          create_list(:registration_exemption, 2, :with_registration, registered_on: first_day_of_the_month)
+
+          expect(Airbrake).to receive(:notify).once
+
+          MonthlyBulkReportService.run(first_day_of_the_month)
+        end
+      end
+    end
+
+    def stub_successful_request
+      stub_request(:put, /https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+/)
+    end
+
+    def stub_failing_request
+      stub_request(
+        :put,
+        /https:\/\/.*\.s3\.eu-west-1\.amazonaws\.com\/20190601-20190630\.csv.+/
+      ).to_return(
+        status: 403
+      )
+    end
+
+    def expect_no_error
+      expect(Airbrake).to_not receive(:notify)
     end
   end
 end


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-392

Implements loading the Bulk report files to Aws bucket using the `defra-ruby-aws` gem.

This also adds end-to-end test coverage. Next step is to implement the records update. 

This is also dependent from: https://github.com/DEFRA/defra-ruby-exporters/pull/9 and https://github.com/DEFRA/defra-ruby-aws/pull/4 