### PR TITLE
Update reports namespace to be consistent

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-namespace :exemptions_reports do
+namespace :reports do
   namespace :generate do
     desc "Generate the bulk montly reports and upload them to S3."
     task bulk: :environment do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-392

Within the codebase we have amended the namespace for our exports to be `reports`. However we didn't make the same change to the rake task namespace used to actually generate them.

This change makes that change.