### PR TITLE
Use the new Reports::GeneratedReport to deal with reports permissions

### DIFF
--- a/app/controllers/bulk_exports_controller.rb
+++ b/app/controllers/bulk_exports_controller.rb
@@ -2,7 +2,7 @@
 
 class BulkExportsController < ApplicationController
   def show
-    authorize! :read, DefraRuby::Exporters::RegistrationBulkExportReport
+    authorize! :read, Reports::GeneratedReport
 
     @bulk_exports = BulkExportsPresenter.new
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/defra_ruby/exporters/registration_bulk_export_report"
-
 class Ability
   include CanCan::Ability
 
@@ -49,6 +47,6 @@ class Ability
     can :use_back_office, :all
     can :read, WasteExemptionsEngine::Registration
     can :read, WasteExemptionsEngine::NewRegistration
-    can :read, DefraRuby::Exporters::RegistrationBulkExportReport
+    can :read, Reports::GeneratedReport
   end
 end

--- a/app/models/reports/generated_report.rb
+++ b/app/models/reports/generated_report.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "defra_ruby/exporters"
-
 module Reports
   class GeneratedReport < ActiveRecord::Base
     self.table_name = :reports_generated_reports

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
                               main_app.users_path %>
                 </li>
               <% end %>
-              <% if can?(:read, DefraRuby::Exporters::RegistrationBulkExportReport) %>
+              <% if can?(:read, Reports::GeneratedReport) %>
                 <li>
                   <%= link_to t("layouts.application.menu.exports"),
                               main_app.bulk_exports_path %>

--- a/spec/support/shared_examples/abilities/data_agent_examples.rb
+++ b/spec/support/shared_examples/abilities/data_agent_examples.rb
@@ -14,6 +14,6 @@ RSpec.shared_examples "data_agent examples" do
   end
 
   it "should be able to view bulk exports" do
-    should be_able_to(:read, DefraRuby::Exporters::RegistrationBulkExportReport)
+    should be_able_to(:read, Reports::GeneratedReport)
   end
 end


### PR DESCRIPTION
From https://eaflood.atlassian.net/browse/RUBY-392

Stop using the old exporters model and instead use the new Reports::GeneratedReport model when dealing with ability permissions