### PR TITLE
Fix namespace for EPR export in schedule.rb

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,7 +19,7 @@ set :job_template, "/bin/bash -l -c 'eval \"$(rbenv init -)\" && :job'"
 # all records and put this into an AWS S3 bucket from which Epimorphics (the
 # company that provides and maintains the EPR) will grab it
 every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "1:05"), roles: [:db] do
-  rake "defra_ruby_exporters:epr"
+  rake "defra_ruby:exporters:epr"
 end
 
 # This is the bulk export job. When run this will create batched CSV exports of

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "Whenever schedule", vcr: true do
     rake_jobs = schedule.jobs[:rake]
     expect(rake_jobs.count).to eq(2)
 
-    epr_jobs = rake_jobs.select { |j| j[:task] == "defra_ruby_exporters:epr" }
+    epr_jobs = rake_jobs.select { |j| j[:task] == "defra_ruby:exporters:epr" }
     bulk_jobs = rake_jobs.select { |j| j[:task] == "reports:generate:bulk" }
     expect(epr_jobs.count).to eq(1)
     expect(bulk_jobs.count).to eq(1)
   end
 
   it "takes the EPR execution time from the appropriate ENV variable" do
-    job_details = schedule.jobs[:rake].find { |h| h[:task] == "defra_ruby_exporters:epr" }
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "defra_ruby:exporters:epr" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-392

The reference to the Defra exporters EPR export in `schedule.rb` was using the old namespace and hence wouldn't work. This change fixes the reference to use the correct namespace.