### PR TITLE
Return blank site address when location is by grid reference

### DIFF
--- a/app/presenters/reports/exemption_bulk_report_presenter.rb
+++ b/app/presenters/reports/exemption_bulk_report_presenter.rb
@@ -66,6 +66,8 @@ module Reports
     # rubocop:enable Naming/PredicateName
 
     def site_location_address
+      return if site_address.located_by_grid_reference?
+
       format_address(site_address)
     end
 

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -206,6 +206,20 @@ module Reports
       it "returns the contact's address" do
         expect(exemption_bulk_report_presenter.site_location_address).to eq("Park, Westland, 45 way, away, Erabor, HD5 JFS")
       end
+
+      context "if the address is located by grid reference" do
+        let(:site_location_address) do
+          build(
+            :address,
+            :site,
+            mode: :auto
+          )
+        end
+
+        it "returns nil" do
+          expect(exemption_bulk_report_presenter.site_location_address).to be_nil
+        end
+      end
     end
 
     describe "#site_location_grid_reference" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-392

Return a nil value for the site address export details when the site is located by a grid reference.