### PR TITLE
Testing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ git:
   depth: 3
 
 before_install:
-  - export TZ=Europe/London
+  - export TZ=UTC
   - gem install -v 1.17.2 bundler --no-rdoc --no-ri
   - sudo apt-get install xvfb -y
   - sudo apt-get install ttf-liberation -y


### PR DESCRIPTION
The travis build seems to be failing for the back office. Error

```bash
0.00s$ cp config/database.travis.yml config/database.yml
before_script.6
2.95s$ RAILS_ENV=test bundle exec rake db:create --trace
The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.
** Invoke db:create (first_time)
** Invoke db:load_config (first_time)
** Execute db:load_config
** Execute db:create
could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```

This is an investigative branch and PR to try and ascertain what is wrong.