### PR TITLE
Downgrade Postgres version to 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: 9.6
+
 env:
   global:
     - CC_TEST_REPORTER_ID=2a9527b01848641303df9a7001121bd4adc106a8f397038e472f75fc6f7c4b75


### PR DESCRIPTION
Following Trravis build failures we have noticed that the travis VM have updated the Postgres version from 9.6 to 10+ when the errrors started appearing.
This downgrade fixes the situation for now.
I am not 100% sure about the real issue, since the current PG gem version is suppose to support postgres 10+.

A ticket have been created to follow up on this:
https://github.com/DEFRA/ruby-services-team/issues/30