### PR TITLE
Change return field for assisted mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: 9.6
+
 env:
   global:
     - CC_TEST_REPORTER_ID=2a9527b01848641303df9a7001121bd4adc106a8f397038e472f75fc6f7c4b75

--- a/app/presenters/reports/exemption_bulk_report_presenter.rb
+++ b/app/presenters/reports/exemption_bulk_report_presenter.rb
@@ -112,7 +112,11 @@ module Reports
     end
 
     def assistance_type
-      registration.assistance_mode
+      if registration.assistance_mode == "full"
+        "fully assisted"
+      else
+        "unassisted"
+      end
     end
 
     def registration_detail_url

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -327,10 +327,22 @@ module Reports
     end
 
     describe "#assistance_type" do
-      let(:registration) { create(:registration, assistance_mode: "unassisted") }
+      let(:registration) { create(:registration, assistance_mode: assistance_mode) }
 
-      it "returns the assistance mode" do
-        expect(exemption_bulk_report_presenter.assistance_type).to eq("unassisted")
+      context "when assistance_mode is blank" do
+        let(:assistance_mode) { nil }
+
+        it "returns the string 'unassisted'" do
+          expect(exemption_bulk_report_presenter.assistance_type).to eq("unassisted")
+        end
+      end
+
+      context "when assistance_mode is set to 'full'" do
+        let(:assistance_mode) { "full" }
+
+        it "returns the string 'fully assisted'" do
+          expect(exemption_bulk_report_presenter.assistance_type).to eq("fully assisted")
+        end
       end
     end
 


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-392 

I was under the impression that since the `assistance_mode` was a string type field with no obvious constraint it would contain just the same string as the CSV. Instead seems like we populate the field to `full` when the registration is a fully assisted one while we leave it blank otherwise.
Fix the code so that we will return the string "fully assisted" when the field is set to "full" and "unassisted" otherwise.

Depends on: https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/218