### PR TITLE
 Remove operator from address data bulk export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: 9.6
+
 env:
   global:
     - CC_TEST_REPORTER_ID=2a9527b01848641303df9a7001121bd4adc106a8f397038e472f75fc6f7c4b75

--- a/app/presenters/reports/exemption_bulk_report_presenter.rb
+++ b/app/presenters/reports/exemption_bulk_report_presenter.rb
@@ -130,7 +130,6 @@ module Reports
 
     def format_address(address)
       [
-        address.organisation,
         address.premises,
         address.street_address,
         address.locality,

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -86,7 +86,6 @@ module Reports
         build(
           :address,
           :operator,
-          organisation: "Park",
           premises: "Westland",
           street_address: "45 way",
           locality: "away",
@@ -98,7 +97,7 @@ module Reports
       let(:registration) { create(:registration, addresses: [organisation_address]) }
 
       it "returns the organisation address" do
-        expect(exemption_bulk_report_presenter.organisation_address).to eq("Park, Westland, 45 way, away, Erabor, HD5 JFS")
+        expect(exemption_bulk_report_presenter.organisation_address).to eq("Westland, 45 way, away, Erabor, HD5 JFS")
       end
     end
 
@@ -123,7 +122,6 @@ module Reports
         build(
           :address,
           :contact,
-          organisation: "Park",
           premises: "Westland",
           street_address: "45 way",
           locality: "away",
@@ -135,7 +133,7 @@ module Reports
       let(:registration) { create(:registration, addresses: [contact_address]) }
 
       it "returns the contact's address" do
-        expect(exemption_bulk_report_presenter.correspondance_contact_address).to eq("Park, Westland, 45 way, away, Erabor, HD5 JFS")
+        expect(exemption_bulk_report_presenter.correspondance_contact_address).to eq("Westland, 45 way, away, Erabor, HD5 JFS")
       end
     end
 
@@ -192,7 +190,6 @@ module Reports
         build(
           :address,
           :site,
-          organisation: "Park",
           premises: "Westland",
           street_address: "45 way",
           locality: "away",
@@ -204,7 +201,7 @@ module Reports
       let(:registration) { create(:registration, addresses: [site_location_address]) }
 
       it "returns the contact's address" do
-        expect(exemption_bulk_report_presenter.site_location_address).to eq("Park, Westland, 45 way, away, Erabor, HD5 JFS")
+        expect(exemption_bulk_report_presenter.site_location_address).to eq("Westland, 45 way, away, Erabor, HD5 JFS")
       end
 
       context "if the address is located by grid reference" do


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-392 

In order to keep consistent with the old bulk export, we are removing the operator field from the addresses in the bulk export data.

Depends on: https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/218