### PR TITLE
Build first reminder email

### DIFF
--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -38,7 +38,7 @@ class RenewalReminderMailer < ActionMailer::Base
     "TODO"
   end
 
-  def exemptions(_registration)
-    ["TODO"]
+  def exemptions(registration)
+    registration.exemptions.map { |ex| "#{ex.code} #{ex.summary}" }
   end
 end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -30,8 +30,8 @@ class RenewalReminderMailer < ActionMailer::Base
     "TODO"
   end
 
-  def reference(_registration)
-    "TODO"
+  def reference(registration)
+    registration.reference
   end
 
   def site_location(_registration)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class RenewalReminderMailer < ActionMailer::Base
+  # So we can use displayable_address()
+  include ::WasteExemptionsEngine::ApplicationHelper
+
   def first_reminder_email(registration)
     @contact_name = contact_name(registration)
     @expiry_date = expiry_date(registration)
@@ -34,8 +37,14 @@ class RenewalReminderMailer < ActionMailer::Base
     registration.reference
   end
 
-  def site_location(_registration)
-    "TODO"
+  def site_location(registration)
+    address = registration.site_address
+
+    if address.postcode.present?
+      displayable_address(address).join(", ")
+    else
+      address.grid_reference
+    end
   end
 
   def exemptions(registration)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -49,6 +49,7 @@ class RenewalReminderMailer < ActionMailer::Base
   end
 
   def exemptions(registration)
-    registration.exemptions.map { |ex| "#{ex.code} #{ex.summary}" }
+    active_exemptions = registration.registration_exemptions.select(&:may_expire?)
+    active_exemptions.map { |ex| "#{ex.exemption.code} #{ex.exemption.summary}" }
   end
 end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -22,8 +22,8 @@ class RenewalReminderMailer < ActionMailer::Base
     "#{config.service_name} <#{config.email_service_email}>"
   end
 
-  def contact_name(_registration)
-    "TODO"
+  def contact_name(registration)
+    "#{registration.contact_first_name} #{registration.contact_last_name}"
   end
 
   def expiry_date(_registration)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -29,8 +29,9 @@ class RenewalReminderMailer < ActionMailer::Base
     "#{registration.contact_first_name} #{registration.contact_last_name}"
   end
 
-  def expiry_date(_registration)
-    "TODO"
+  def expiry_date(registration)
+    # Currently you can only add exemptions when you register, so we can assume they expire at the same time
+    registration.registration_exemptions.first.expires_on.to_formatted_s(:day_month_year)
   end
 
   def reference(registration)

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class RenewalReminderMailer < ActionMailer::Base
+  def first_reminder_email(registration)
+    @contact_name = contact_name(registration)
+    @expiry_date = expiry_date(registration)
+    @reference = reference(registration)
+    @site_location = site_location(registration)
+    @exemptions = exemptions(registration)
+
+    mail(
+      to: registration.contact_email,
+      from: from_email,
+      subject: I18n.t(".renewal_reminder_mailer.first_reminder_email.subject")
+    )
+  end
+
+  private
+
+  def from_email
+    config = WasteExemptionsEngine.configuration
+    "#{config.service_name} <#{config.email_service_email}>"
+  end
+
+  def contact_name(_registration)
+    "TODO"
+  end
+
+  def expiry_date(_registration)
+    "TODO"
+  end
+
+  def reference(_registration)
+    "TODO"
+  end
+
+  def site_location(_registration)
+    "TODO"
+  end
+
+  def exemptions(_registration)
+    ["TODO"]
+  end
+end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -41,10 +41,10 @@ class RenewalReminderMailer < ActionMailer::Base
   def site_location(registration)
     address = registration.site_address
 
-    if address.postcode.present?
-      displayable_address(address).join(", ")
-    else
+    if address.located_by_grid_reference?
       address.grid_reference
+    else
+      displayable_address(address).join(", ")
     end
   end
 

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -1,0 +1,188 @@
+
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style type="text/css">
+        <!--
+        body {
+            margin: 0 !important
+        }
+        -->
+    </style>
+
+
+</head>
+
+<body style="font-family:Helvetica,Arial,sans-serif; font-size:16px; margin:0; color:#0b0c0c" fpstyle="1" ocsi="0">
+    <div style="direction: ltr;font-family: Arial;color: #000000;font-size: 12pt;">
+
+        <div style="font-family: Times New Roman; color: #000000; font-size: 16px">
+
+            <div>
+                <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse; min-width:100%; width:100%!important">
+                    <tbody>
+                        <tr>
+                            <td width="100%" height="53" bgcolor="#0b0c0c">
+                                <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse; max-width:580px">
+                                    <tbody>
+                                        <tr>
+                                            <td width="70" bgcolor="#0b0c0c" valign="middle">
+                                                <a href="https://www.gov.uk" style="text-decoration:none" target="_blank" rel="noopener noreferrer">
+                                                    <table cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse">
+                                                        <tbody>
+                                                            <tr>
+                                                                <td style="padding-left:30px"><img src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png" alt="" style="margin-top:4px" height="32" border="0">
+                                                                </td>
+                                                                <td style="font-size:28px; line-height:1.315789474; margin-top:4px; padding-left:10px">
+                                                                    <span style="font-family:Helvetica,Arial,sans-serif; font-weight:700; color:#ffffff; text-decoration:none; vertical-align:top; display:inline-block">GOV.UK</span>
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <!-- WRAPPER FOR OUTLOOK USING OFFICE RENDERER -->
+                <!--[if mso]>
+                <table cellpadding="0" cellspacing="0" border="1" style="padding:0px;margin:0px;width:580px;" width="580">
+                    <tr>
+                        <td style="padding:0px;margin:0px;" width="580">
+                <![endif]-->
+
+                <table class="content" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse; max-width:580px; width:100%!important">
+                    <tbody>
+                        <tr>
+                            <td width="10" height="10" valign="middle"></td>
+                            <td>
+                                <table width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse">
+                                    <tbody>
+                                        <tr>
+                                            <td bgcolor="#005EA5" width="100%" height="10"></td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </td>
+                            <td width="10" valign="middle" height="10"></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table class="content" cellpadding="0" cellspacing="0" border="0" width="100%" style="border-collapse:collapse; max-width:580px; width:100%!important">
+                    <tbody>
+                        <tr>
+                            <td width="10" valign="middle">
+                                <br>
+                            </td>
+                            <td style="font-family:Helvetica,Arial,sans-serif; font-size:19px; line-height:1.315789474; max-width:560px">
+                                <p style="margin:30px 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".salutation", name: @contact_name) %>
+                                </p>
+
+                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                    <%= t(".section_1.subheading", date: @expiry_date) %>
+                                </h2>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_1.reference_label") %> <%= @reference %>
+                                </p>
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_1.site_label") %> <%= @site_location %>
+                                </p>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                  <%= t(".section_1.exemptions_label") %>
+                                </p>
+
+                                <ul style="margin:0 0 0 20px; padding:0; list-style-type:disc">
+                                  <% @exemptions.each do |exemption| %>
+                                    <li style="margin:5px 0 5px; padding:0 0 0 5px; font-size:19px; line-height:25px; color:#0B0C0C">
+                                      <%= exemption %>
+                                    </li>
+                                  <% end %>
+                                </ul>
+
+                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                    <%= t(".section_2.subheading") %>
+                                </h2>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_2.paragraph_1") %>
+                                </p>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C; font-weight:bold;">
+                                    <%= t(".section_2.register_label") %>
+                                    <a href="<%= t(".section_2.register_url") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_2.register_url") %>
+                                    </a>
+                                </p>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_2.paragraph_2") %>
+                                </p>
+
+                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                    <%= t(".section_3.subheading") %>
+                                </h2>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_3.paragraph_1") %>
+                                    <a href="mailto: <%= t(".section_3.paragraph_1_email") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_3.paragraph_1_email") %>
+                                    </a>
+                                </p>
+
+                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                    <%= t(".section_4.subheading") %>
+                                </h2>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_4.paragraph_1") %>
+                                    <a href="<%= t(".section_4.paragraph_1_link") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_4.paragraph_1_link") %>
+                                    </a>
+                                </p>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".section_4.paragraph_2") %>
+                                    <a href="<%= t(".section_4.paragraph_2_link") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_4.paragraph_2_link") %>
+                                    </a>
+                                </p>
+
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".sign_off.paragraph_1") %>
+                                </p>
+                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                    <%= t(".sign_off.paragraph_2") %>
+                                </p>
+                            </td>
+                            <td width="10" valign="middle">
+                                <br>
+                            </td>
+                        </tr>
+
+                    </tbody>
+                </table>
+
+                <!-- END WRAPPER -->
+                <!--[if mso]>
+                        </td>
+                    </tr>
+                  </table>
+                <![endif]-->
+
+            </div>
+        </div>
+    </div>
+
+</body>
+
+</html>

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -98,7 +98,7 @@
                                 </p>
 
                                 <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
-                                  <%= t(".section_1.exemptions_label") %>
+                                  <%= t(".section_1.exemptions_label", date: @expiry_date) %>
                                 </p>
 
                                 <ul style="margin:0 0 0 20px; padding:0; list-style-type:disc">

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -86,9 +86,9 @@
                                     <%= t(".salutation", name: @contact_name) %>
                                 </p>
 
-                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                <h1 style="margin:0 0 20px 0; padding:0; font-size:30px; line-height:38px; font-weight:bold; color:#0B0C0C">
                                     <%= t(".section_1.subheading", date: @expiry_date) %>
-                                </h2>
+                                </h1>
 
                                 <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
                                     <%= t(".section_1.reference_label") %> <%= @reference %>
@@ -97,7 +97,7 @@
                                     <%= t(".section_1.site_label") %> <%= @site_location %>
                                 </p>
 
-                                <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
+                                <p style="margin:0 0 10px 0; font-size:19px; line-height:25px; color:#0B0C0C">
                                   <%= t(".section_1.exemptions_label", date: @expiry_date) %>
                                 </p>
 
@@ -109,7 +109,7 @@
                                   <% end %>
                                 </ul>
 
-                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                <h2 style="margin:20px 0 4px 0; padding:0; font-size:22px; line-height:35px; font-weight:bold; color:#0B0C0C">
                                     <%= t(".section_2.subheading") %>
                                 </h2>
 
@@ -128,7 +128,7 @@
                                     <%= t(".section_2.paragraph_2") %>
                                 </p>
 
-                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                <h2 style="margin:20px 0 4px 0; padding:0; font-size:22px; line-height:35px; font-weight:bold; color:#0B0C0C">
                                     <%= t(".section_3.subheading") %>
                                 </h2>
 
@@ -139,7 +139,7 @@
                                     </a>
                                 </p>
 
-                                <h2 style="margin:0 0 20px 0; padding:0; font-size:27px; line-height:35px; font-weight:bold; color:#0B0C0C">
+                                <h2 style="margin:20px 0 4px 0; padding:0; font-size:22px; line-height:35px; font-weight:bold; color:#0B0C0C">
                                     <%= t(".section_4.subheading") %>
                                 </h2>
 

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -119,8 +119,8 @@
 
                                 <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C; font-weight:bold;">
                                     <%= t(".section_2.register_label") %>
-                                    <a href="<%= t(".section_2.register_url") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
-                                        <%= t(".section_2.register_url") %>
+                                    <a href="<%= t(".section_2.register_link_url") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_2.register_link_text") %>
                                     </a>
                                 </p>
 
@@ -145,15 +145,15 @@
 
                                 <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
                                     <%= t(".section_4.paragraph_1") %>
-                                    <a href="<%= t(".section_4.paragraph_1_link") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
-                                        <%= t(".section_4.paragraph_1_link") %>
+                                    <a href="<%= t(".section_4.paragraph_1_link_url") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_4.paragraph_1_link_text") %>
                                     </a>
                                 </p>
 
                                 <p style="margin:0 0 20px 0; font-size:19px; line-height:25px; color:#0B0C0C">
                                     <%= t(".section_4.paragraph_2") %>
-                                    <a href="<%= t(".section_4.paragraph_2_link") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
-                                        <%= t(".section_4.paragraph_2_link") %>
+                                    <a href="<%= t(".section_4.paragraph_2_link_url") %>" style="word-wrap:break-word; color:#005ea5" target="_blank" rel="noopener noreferrer">
+                                        <%= t(".section_4.paragraph_2_link_text") %>
                                     </a>
                                 </p>
 

--- a/app/views/renewal_reminder_mailer/first_reminder_email.txt.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.txt.erb
@@ -15,7 +15,7 @@
 
 <%= t(".section_2.paragraph_1") %>
 
-<%= t(".section_2.register_label") %> <%= t(".section_2.register_url") %>
+<%= t(".section_2.register_label") %> <%= t(".section_2.register_link_url") %>
 
 <%= t(".section_2.paragraph_2") %>
 
@@ -25,9 +25,9 @@
 
 <%= t(".section_4.subheading") %>
 
-<%= t(".section_4.paragraph_1") %> <%= t(".section_4.paragraph_1_link") %>
+<%= t(".section_4.paragraph_1") %> <%= t(".section_4.paragraph_1_link_url") %>
 
-<%= t(".section_4.paragraph_2") %> <%= t(".section_4.paragraph_2_link") %>
+<%= t(".section_4.paragraph_2") %> <%= t(".section_4.paragraph_2_link_url") %>
 
 <%= t(".sign_off.paragraph_1") %>
 <%= t(".sign_off.paragraph_2") %>

--- a/app/views/renewal_reminder_mailer/first_reminder_email.txt.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.txt.erb
@@ -1,0 +1,33 @@
+<%= t(".salutation", name: @contact_name) %>
+
+<%= t(".section_1.subheading", date: @expiry_date) %>
+
+<%= t(".section_1.reference_label") %> <%= @reference %>
+<%= t(".section_1.site_label") %> <%= @site_location %>
+
+<%= t(".section_1.exemptions_label", date: @expiry_date) %>
+
+<% @exemptions.each do |exemption| %>
+- <%= exemption %>
+<% end %>
+
+<%= t(".section_2.subheading") %>
+
+<%= t(".section_2.paragraph_1") %>
+
+<%= t(".section_2.register_label") %> <%= t(".section_2.register_url") %>
+
+<%= t(".section_2.paragraph_2") %>
+
+<%= t(".section_3.subheading") %>
+
+<%= t(".section_3.paragraph_1") %> <%= t(".section_3.paragraph_1_email") %>
+
+<%= t(".section_4.subheading") %>
+
+<%= t(".section_4.paragraph_1") %> <%= t(".section_4.paragraph_1_link") %>
+
+<%= t(".section_4.paragraph_2") %> <%= t(".section_4.paragraph_2_link") %>
+
+<%= t(".sign_off.paragraph_1") %>
+<%= t(".sign_off.paragraph_2") %>

--- a/config/locales/mailers/renewal_reminder_email.en.yml
+++ b/config/locales/mailers/renewal_reminder_email.en.yml
@@ -1,0 +1,30 @@
+
+en:
+  renewal_reminder_mailer:
+    first_reminder_email:
+      subject: "Your waste exemptions expire soon, register again to continue your waste operations"
+      salutation: "Dear %{name}"
+      section_1:
+        subheading: "Your waste exemptions registration expires on %{date}."
+        reference_label: "Waste exemptions registration number:"
+        site_label: "Site location:"
+        exemptions_label: "These waste exemption(s) will expire on %{date}:"
+      section_2:
+        subheading: "Register your waste exemptions now"
+        paragraph_1: "Until our online renewal service is launched, you’ll need to register your exemptions again."
+        register_label: "Register here:"
+        register_url: "www.gov.uk/register-waste-exemption"
+        paragraph_2: "If you no longer carry out these waste operations, you do not need to do anything. Your exemptions will be removed from the public register when they expire."
+      section_3:
+        subheading: "Need help to register?"
+        paragraph_1: "Call us on 03708 506 506 to register by phone (Monday to Friday, 8am to 6pm), or email:"
+        paragraph_1_email: "enquiries@environment-agency.gov.uk"
+      section_4:
+        subheading: "Waste exemptions guidance"
+        paragraph_1: "You must read and understand the limits and conditions of each exemption before you renew. Guidance is available online at:"
+        paragraph_1_link: "www.gov.uk/register-waste-exemption"
+        paragraph_2: "View your previous waste exemptions on the public register at:"
+        paragraph_2_link: "www.gov.uk/access-the-public-register-for-environmental-information"
+      sign_off:
+        paragraph_1: "Yours sincerely"
+        paragraph_2: "Waste Exemptions Team"

--- a/config/locales/mailers/renewal_reminder_email.en.yml
+++ b/config/locales/mailers/renewal_reminder_email.en.yml
@@ -13,7 +13,8 @@ en:
         subheading: "Register your waste exemptions now"
         paragraph_1: "Until our online renewal service is launched, you’ll need to register your exemptions again."
         register_label: "Register here:"
-        register_url: "www.gov.uk/register-waste-exemption"
+        register_link_text: "www.gov.uk/register-waste-exemption"
+        register_link_url: "https://www.gov.uk/register-waste-exemption"
         paragraph_2: "If you no longer carry out these waste operations, you do not need to do anything. Your exemptions will be removed from the public register when they expire."
       section_3:
         subheading: "Need help to register?"
@@ -22,9 +23,11 @@ en:
       section_4:
         subheading: "Waste exemptions guidance"
         paragraph_1: "You must read and understand the limits and conditions of each exemption before you renew. Guidance is available online at:"
-        paragraph_1_link: "www.gov.uk/register-waste-exemption"
+        paragraph_1_link_text: "www.gov.uk/register-waste-exemption"
+        paragraph_1_link_url: "https://www.gov.uk/register-waste-exemption"
         paragraph_2: "View your previous waste exemptions on the public register at:"
-        paragraph_2_link: "www.gov.uk/access-the-public-register-for-environmental-information"
+        paragraph_2_link_text: "www.gov.uk/access-the-public-register-for-environmental-information"
+        paragraph_2_link_url: "https://www.gov.uk/access-the-public-register-for-environmental-information"
       sign_off:
         paragraph_1: "Yours sincerely"
         paragraph_2: "Waste Exemptions Team"

--- a/lib/tasks/one_off/reminders.rake
+++ b/lib/tasks/one_off/reminders.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :reminder do
+  desc "Send an example first renewal email"
+  task first: :environment do
+    registration = WasteExemptionsEngine::Registration.last
+    RenewalReminderMailer.first_reminder_email(registration).deliver_now
+  end
+end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
 
     trait :site do
       address_type { :site }
+      mode { :auto }
       description { "The waste is stored in an out-building next to the barn." }
       grid_reference { "ST 58337 72855" }
 
@@ -59,7 +60,8 @@ FactoryBot.define do
     end
 
     trait :site_uses_address do
-      address_type { 3 }
+      address_type { :site }
+      mode { :lookup }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -86,7 +86,13 @@ FactoryBot.define do
     end
 
     trait :with_active_exemptions do
-      registration_exemptions { build_list(:registration_exemption, 5, state: :active) }
+      after(:build) do |reg|
+        reg.registration_exemptions.each do |re|
+          re.state = :active
+          re.expires_on = Date.today + 3.years
+          re.registered_on = Date.today
+        end
+      end
     end
   end
 end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RenewalReminderMailer, type: :mailer do
+  describe "test_email" do
+    before do
+      allow(WasteExemptionsEngine.configuration).to receive(:email_service_email).and_return("wex@example.com")
+      allow(WasteExemptionsEngine.configuration).to receive(:service_name).and_return("WEX")
+    end
+
+    let(:registration) { build(:registration) }
+    let(:mail) { RenewalReminderMailer.first_reminder_email(registration) }
+
+    it "uses the correct 'to' address" do
+      expect(mail.to).to eq([registration.contact_email])
+    end
+
+    it "uses the correct 'from' address" do
+      expect(mail.from).to eq(["wex@example.com"])
+    end
+
+    it "uses the correct subject" do
+      subject = "Your waste exemptions expire soon, register again to continue your waste operations"
+      expect(mail.subject).to eq(subject)
+    end
+
+    it "includes the correct template in the body" do
+      expect(mail.body.encoded).to include("Until our online renewal service is launched, you’ll need to register your exemptions again.")
+    end
+  end
+end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       expect(mail.body.encoded).to include(reference)
     end
 
+    it "includes the correct grid reference" do
+      grid_reference = registration.site_address.grid_reference
+      expect(mail.body.encoded).to include(grid_reference)
+    end
+
+    context "when the site address is an address" do
+      let(:registration) { build(:registration, :site_uses_address) }
+
+      it "includes the correct address" do
+        address = registration.site_address
+        address_text = "#{address.premises}, #{address.street_address}, #{address.locality}, #{address.city}, #{address.postcode}"
+        expect(mail.body.encoded).to include(address_text)
+      end
+    end
+
     it "includes the correct exemptions" do
       registration.exemptions.each do |exemption|
         exemption_text = "#{exemption.code} #{exemption.summary}"

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -33,5 +33,10 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       contact_name = "#{registration.contact_first_name} #{registration.contact_last_name}"
       expect(mail.body.encoded).to include(contact_name)
     end
+
+    it "includes the correct reference" do
+      reference = registration.reference
+      expect(mail.body.encoded).to include(reference)
+    end
   end
 end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -28,5 +28,10 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     it "includes the correct template in the body" do
       expect(mail.body.encoded).to include("Until our online renewal service is launched, you’ll need to register your exemptions again.")
     end
+
+    it "includes the correct contact name" do
+      contact_name = "#{registration.contact_first_name} #{registration.contact_last_name}"
+      expect(mail.body.encoded).to include(contact_name)
+    end
   end
 end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -38,5 +38,12 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       reference = registration.reference
       expect(mail.body.encoded).to include(reference)
     end
+
+    it "includes the correct exemptions" do
+      registration.exemptions.each do |exemption|
+        exemption_text = "#{exemption.code} #{exemption.summary}"
+        expect(mail.body.encoded).to include(exemption_text)
+      end
+    end
   end
 end

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       allow(WasteExemptionsEngine.configuration).to receive(:service_name).and_return("WEX")
     end
 
-    let(:registration) { build(:registration) }
+    let(:registration) { build(:registration, :with_active_exemptions) }
     let(:mail) { RenewalReminderMailer.first_reminder_email(registration) }
 
     it "uses the correct 'to' address" do
@@ -34,6 +34,11 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       expect(mail.body.encoded).to include(contact_name)
     end
 
+    it "includes the correct expiry date" do
+      expires_on = registration.registration_exemptions.first.expires_on.to_formatted_s(:day_month_year)
+      expect(mail.body.encoded).to include(expires_on)
+    end
+
     it "includes the correct reference" do
       reference = registration.reference
       expect(mail.body.encoded).to include(reference)
@@ -45,7 +50,7 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     context "when the site address is an address" do
-      let(:registration) { build(:registration, :site_uses_address) }
+      let(:registration) { build(:registration, :site_uses_address, :with_active_exemptions) }
 
       it "includes the correct address" do
         address = registration.site_address

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -59,11 +59,17 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       end
     end
 
-    it "includes the correct exemptions" do
-      registration.exemptions.each do |exemption|
-        exemption_text = "#{exemption.code} #{exemption.summary}"
-        expect(mail.body.encoded).to include(exemption_text)
-      end
+    it "includes active exemptions" do
+      re = registration.registration_exemptions.first
+      exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
+      expect(mail.body.encoded).to include(exemption_text)
+    end
+
+    it "excludes inactive exemptions" do
+      re = registration.registration_exemptions.last
+      re.state = :ceased
+      exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
+      expect(mail.body.encoded).to_not include(exemption_text)
     end
   end
 end

--- a/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_bulk_report_presenter_spec.rb
@@ -189,7 +189,7 @@ module Reports
       let(:site_location_address) do
         build(
           :address,
-          :site,
+          :site_uses_address,
           premises: "Westland",
           street_address: "45 way",
           locality: "away",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-252

This is the first reminder email that digital users will get. It should be sent 4 weeks before the registration is due to expire.

This story covers building the mailer and putting the HTML and text into the code.

![email-screenshot](https://user-images.githubusercontent.com/13369917/60184334-c6e7d100-981f-11e9-964e-654940f108a7.png)

You can test this with the last registration in the database by running `bundle exec rake reminder:first`. (We'll rip this out once we have something actually triggering it, but for now this is there for testing.)