### PR TITLE
Fix defra_ruby_aws gem name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ gem "waste_exemptions_engine",
     branch: "master"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
-gem "defra-ruby-aws",
+gem "defra_ruby_aws",
     git: "https://github.com/DEFRA/defra-ruby-aws",
     branch: "master"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DEFRA/defra-ruby-aws
-  revision: 0c25a938b94bb36a6dc9def6fe3cfb24988be029
+  revision: 6c3b832c865434df33d06f16f64563732a3c9ae5
   branch: master
   specs:
-    defra-ruby-aws (0.0.1)
+    defra_ruby_aws (0.1.0)
       aws-sdk-s3
 
 GIT
@@ -73,17 +73,17 @@ GEM
     arel (6.0.4)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.174.0)
-    aws-sdk-core (3.54.2)
+    aws-partitions (1.177.0)
+    aws-sdk-core (3.56.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.21.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-kms (1.22.0)
+      aws-sdk-core (~> 3, >= 3.56.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.42.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-s3 (1.43.0)
+      aws-sdk-core (~> 3, >= 3.56.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
@@ -373,7 +373,7 @@ DEPENDENCIES
   bullet (~> 5.9)
   cancancan (~> 2.0)
   database_cleaner
-  defra-ruby-aws!
+  defra_ruby_aws!
   defra_ruby_style
   devise (>= 4.4.3)
   devise_invitable (~> 1.7.0)


### PR DESCRIPTION
We renamed this to use snake case instead of kebab case.

Resolves https://github.com/DEFRA/waste-exemptions-back-office-ta/issues/232