### PR TITLE
Use registration state when displaying registrations in the dashboard

### DIFF
--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -14,7 +14,7 @@ module DashboardsHelper
   def status_tag_for(result)
     return :pending if result.is_a?(WasteExemptionsEngine::NewRegistration)
 
-    :active
+    result.state
   end
 
   def result_name_for_visually_hidden_text(result)

--- a/config/locales/partials/search_result.en.yml
+++ b/config/locales/partials/search_result.en.yml
@@ -14,6 +14,9 @@ en:
       statuses:
         active: "active"
         pending: "not yet submitted"
+        revoked: "revoked"
+        ceased: "ceased"
+        expired: "expired"
       actions:
         view:
           link_text: "View details"

--- a/spec/helpers/dashboards_helper_spec.rb
+++ b/spec/helpers/dashboards_helper_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe DashboardsHelper, type: :helper do
       let(:result) { build(:registration) }
 
       it "returns :active" do
-        expect(helper.status_tag_for(result)).to eq(:active)
+        expect(helper.status_tag_for(result)).to eq(result.state)
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-432

Use the registration state on the dashboard in order for a user to have a visual information about the registration status.

<img width="1323" alt="Screenshot 2019-06-25 at 15 13 22" src="https://user-images.githubusercontent.com/1385397/60107323-9ee46900-975e-11e9-9692-260ad789c633.png">
