### PR TITLE
Fix HTML W3C issues

### DIFF
--- a/app/views/deregister_exemptions/new.html.erb
+++ b/app/views/deregister_exemptions/new.html.erb
@@ -18,10 +18,11 @@
           <span class="error-message"><%= @deregister_exemptions_form.errors[:state_transition].join(", ") %></span>
           <% end %>
 
-          <%= f.label :state_transition, class: "form-label" do %>
+          <label class="form-label">
             <%= t(".labels.state_transition") %>
             <span class="form-hint"><%= t(".labels.state_transition_hint") %></span>
-          <% end %>
+          </label>
+
           <% @deregister_exemptions_form.state_transition_options.each do |state_transition| %>
             <div class="multiple-choice">
               <%= f.radio_button :state_transition, state_transition %>
@@ -48,7 +49,7 @@
             <span class="form-hint"><%= t(".labels.message_hint") %></span>
           </legend>
 
-          <fieldset id="message">
+          <fieldset>
             <%= f.text_area :message, value: @deregister_exemptions_form.message, class: "form-control", rows: 4 %>
           </fieldset>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,28 +11,28 @@
   <div class="header-proposition">
     <div class="content">
       <% if user_signed_in? %>
-          <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>
-          <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="proposition-menu" aria-label="Show or hide Top Level Navigation">Menu</a>
-          <nav id="proposition-menu">
-            <ul id="proposition-links" aria-label="Top Level Navigation">
+        <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>
+        <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="proposition-menu" aria-label="Show or hide Top Level Navigation">Menu</a>
+        <nav id="proposition-menu">
+          <ul id="proposition-links" aria-label="Top Level Navigation">
+            <li>
+              <%= link_to t("layouts.application.menu.dashboard"),
+                          main_app.root_path %>
+            </li>
+            <% if can?(:read, current_user) %>
               <li>
-                <%= link_to t("layouts.application.menu.dashboard"),
-                            main_app.root_path %>
+                <%= link_to t("layouts.application.menu.users"),
+                            main_app.users_path %>
               </li>
-              <% if can?(:read, current_user) %>
-                <li>
-                  <%= link_to t("layouts.application.menu.users"),
-                              main_app.users_path %>
-                </li>
-              <% end %>
-              <% if can?(:read, Reports::GeneratedReport) %>
-                <li>
-                  <%= link_to t("layouts.application.menu.exports"),
-                              main_app.bulk_exports_path %>
-                </li>
-              <% end %>
-            </ul>
-          </nav>
+            <% end %>
+            <% if can?(:read, Reports::GeneratedReport) %>
+              <li>
+                <%= link_to t("layouts.application.menu.exports"),
+                            main_app.bulk_exports_path %>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
       <% else %>
         <nav id="proposition-menu">
           <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,8 @@
   <div class="header-proposition">
     <div class="content">
       <% if user_signed_in? %>
-        <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>
-        <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</a>
+          <%= link_to t(:global_proposition_header), main_app.root_path, id: "proposition-name" %>
+          <a role="button" href="#proposition-links" class="js-header-toggle menu" aria-controls="proposition-menu" aria-label="Show or hide Top Level Navigation">Menu</a>
           <nav id="proposition-menu">
             <ul id="proposition-links" aria-label="Top Level Navigation">
               <li>

--- a/app/views/shared/_resource_address.html.erb
+++ b/app/views/shared/_resource_address.html.erb
@@ -1,7 +1,7 @@
 <% if address.operator? %>
   <h3 class="heading-small">
     <%= t(".heading.#{address.address_type}") %>
-  </h2>
+  </h3>
 <% else %>
   <h2 class="heading-medium">
     <%= t(".heading.#{address.address_type}") %>

--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -84,7 +84,7 @@
           <%= t(".labels.contact_email") %>
         </h3>
         <p>
-          <a href="mailto: <%= resource.contact_email %>">
+          <a href="mailto:<%= resource.contact_email %>">
             <%= resource.contact_email %>
           </a>
         </p>


### PR DESCRIPTION
From https://eaflood.atlassian.net/browse/RUBY-388

Fixes HTML issues from W3C validation

It does not include test coverage which is currently blocked due to an issue with cancancan abilities in the test suite

Issue fixed were about: 
- Misplaced / duplicated tag ids 
- Space in the `mailto` link 
- label `for` attribute pointing to non-existing objects 
- `aria-controls` tag pointing to the wrong object