### PR TITLE
Update bulk exporter schedule to be daily

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,6 @@ EMAIL_SERVICE_EMAIL=""
 EXPORT_SERVICE_BATCH_SIZE=10
 EXPORT_SERVICE_EPR_EXPORT_TIME="1:05"
 EXPORT_SERVICE_CRON_LOG_OUTPUT_PATH='/home/rails/waste-exemptions-back-office/shared/log/'
-# This can be any day of the week or 'day' for daily.
-EXPORT_SERVICE_BULK_EXPORT_FREQUENCY="sunday"
 EXPORT_SERVICE_BULK_EXPORT_TIME="20:05"
 
 # AWS config

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,10 +22,9 @@ every :day, at: (ENV["EXPORT_SERVICE_EPR_EXPORT_TIME"] || "1:05"), roles: [:db] 
   rake "reports:generate:epr"
 end
 
-# This is the bulk export job. When run this will create batched CSV exports of
-# all records and put these files into an AWS S3 bucket.
-bulk_frequency = (ENV["EXPORT_SERVICE_BULK_EXPORT_FREQUENCY"] || :sunday).to_sym
+# This is the daily bulk export job. When run this will create batched CSV
+# exports of all records and put these files into an AWS S3 bucket.
 bulk_time = (ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"] || "20:05")
-every bulk_frequency, at: bulk_time, roles: [:db] do
+every :day, at: bulk_time, roles: [:db] do
   rake "reports:generate:bulk"
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Whenever schedule" do
   it "takes the bulk export execution time and frequency from the appropriate ENV variables" do
     job_details = schedule.jobs[:rake].find { |h| h[:task] == "reports:generate:bulk" }
 
-    expect(job_details[:every][0]).to eq(ENV["EXPORT_SERVICE_BULK_EXPORT_FREQUENCY"].to_sym)
+    expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["EXPORT_SERVICE_BULK_EXPORT_TIME"])
   end
 


### PR DESCRIPTION
Now we have completed the migrations work, we have been able to run the bulk export in pre-production with production volumes. It currently takes 23 minutes, and we believe that is perfectly acceptable as a daily rather than weekly job.

Hence this change which removes the frequency element of the bulk export schedule, setting it to run daily at 20:05.