### PR TITLE
Rename email reminders task to include `first`

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,5 +33,5 @@ end
 # Will run once a day in the early morning hours and send email reminders about
 # registrations that will expire in X time.
 every :day, at: (ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"] || "1:05"), roles: [:db] do
-  rake "email:renew_reminder:send"
+  rake "email:renew_reminder:first:send"
 end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -7,9 +7,11 @@ namespace :email do
   end
 
   namespace :renew_reminder do
-    desc "Collect all registration that expires in 4 weeks and sends an email reminder"
-    task send: :environment do
-      FirstRenewalReminderService.run
+    namespace :first do
+      desc "Collect all registration that expires in 4 weeks and sends an email reminder"
+      task send: :environment do
+        FirstRenewalReminderService.run
+      end
     end
   end
 end

--- a/spec/schedule_spec.rb
+++ b/spec/schedule_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Whenever schedule" do
   end
 
   it "takes the email reminder execution time from the appropriate ENV variable" do
-    job_details = schedule.jobs[:rake].find { |h| h[:task] == "email:renew_reminder:send" }
+    job_details = schedule.jobs[:rake].find { |h| h[:task] == "email:renew_reminder:first:send" }
 
     expect(job_details[:every][0]).to eq(:day)
     expect(job_details[:every][1][:at]).to eq(ENV["FIRST_RENEWAL_EMAIL_REMINDER_DAILY_RUN_TIME"])


### PR DESCRIPTION
This renames the Email reminders to include `first` so that we can distinguish between the first and second email reminders later on.

Open to suggestion. I am not super super happy about this naming 🤔 