### PR TITLE
Add missing mailto to link

### DIFF
--- a/app/views/shared/_resource_details.html.erb
+++ b/app/views/shared/_resource_details.html.erb
@@ -37,7 +37,7 @@
           <%= t(".labels.applicant_email") %>
         </h3>
         <p>
-          <a href="<%= resource.applicant_email %>">
+          <a href="mailto:<%= resource.applicant_email %>">
             <%= resource.applicant_email %>
           </a>
         </p>


### PR DESCRIPTION
From https://eaflood.atlassian.net/browse/RUBY-383

This was missing the `mailto:` entirely while the other one fixed had an empty space.