### PR TITLE
Fix error when in confirmation letter for expired

### DIFF
--- a/app/presenters/confirmation_letter_presenter.rb
+++ b/app/presenters/confirmation_letter_presenter.rb
@@ -61,7 +61,7 @@ class ConfirmationLetterPresenter < BasePresenter
   end
 
   def registration_exemption_status(registration_exemption)
-    display_date = if registration_exemption.state == "active"
+    display_date = if registration_exemption.state == "active" || registration_exemption.state == "expired"
                      registration_exemption.expires_on.to_formatted_s(:day_month_year)
                    else
                      registration_exemption.deregistered_at.to_formatted_s(:day_month_year)

--- a/app/presenters/confirmation_letter_presenter.rb
+++ b/app/presenters/confirmation_letter_presenter.rb
@@ -61,7 +61,7 @@ class ConfirmationLetterPresenter < BasePresenter
   end
 
   def registration_exemption_status(registration_exemption)
-    display_date = if registration_exemption.state == "active" || registration_exemption.state == "expired"
+    display_date = if registration_exemption.active? || registration_exemption.expired?
                      registration_exemption.expires_on.to_formatted_s(:day_month_year)
                    else
                      registration_exemption.deregistered_at.to_formatted_s(:day_month_year)

--- a/config/locales/confirmation_letters.en.yml
+++ b/config/locales/confirmation_letters.en.yml
@@ -73,6 +73,7 @@ en:
           active: "Expires on %{display_date}"
           ceased: "Ceased on %{display_date}"
           revoked: "Revoked on %{display_date}"
+          expired: "Expired on %{display_date}"
       deregistered_exemptions:
         title: De-registered exemptions
       contact_us:

--- a/spec/presenters/confirmation_letter_presenter_spec.rb
+++ b/spec/presenters/confirmation_letter_presenter_spec.rb
@@ -141,5 +141,13 @@ RSpec.describe ConfirmationLetterPresenter do
         expect(subject.registration_exemption_status(registration_exemption)).to eq("Revoked on 1 April 2019")
       end
     end
+
+    context "when the registration exemption is expired" do
+      let(:registration_exemption) { build(:registration_exemption, :expired) }
+
+      it "returns a string representation that states when the exemption was expired" do
+        expect(subject.registration_exemption_status(registration_exemption)).to eq("Expired on 2 April 2022")
+      end
+    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-453

Prior to this change if the registration contained an exemption with a state of `expired` it would error when the user attempted to view the confirmation letter.

A quick check of the code identified that the logic in the `ConfirmationLetterPresenter.registration_exemption_status()` method would attempt to generate a display version of the deregistered date for any exemption without a status of `active`.

The problem is that an expired exemption does not have a deregistered date hence the code was failing. So a quick tweak of the logic and 🎉 we have a working confirmation letter.