### PR TITLE
Fix bug on first day of the month bulk report generation

### DIFF
--- a/app/services/reports/bulk_export_service.rb
+++ b/app/services/reports/bulk_export_service.rb
@@ -9,7 +9,7 @@ module Reports
 
       first_day_of_the_month = starts_from
 
-      while first_day_of_the_month < Date.today
+      while first_day_of_the_month <= Date.today
         MonthlyBulkReportService.run(first_day_of_the_month)
 
         first_day_of_the_month = first_day_of_the_month.next_month


### PR DESCRIPTION
When the current date is the first day of the month, we expect the report service to generate a document for the current month as well.
This wasn't the case, and the test suite issue happening on the first day of the month sparked light on the bug.