### PR TITLE
Do not seed exemptions in the test suite, use factories instead

### DIFF
--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
        build(:transient_address, :site)]
     end
 
-    exemptions { WasteExemptionsEngine::Exemption.all }
+    exemptions { build_list(:exemption, 5) }
 
     transient_people { [build(:transient_person), build(:transient_person)] }
   end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
 
     submitted_at { DateTime.now }
 
-    exemptions { WasteExemptionsEngine::Exemption.first(3) }
+    registration_exemptions { build_list(:registration_exemption, 3) }
 
     sequence :applicant_email do |n|
       "applicant#{n}@example.com"

--- a/spec/models/registration_exemption_spec.rb
+++ b/spec/models/registration_exemption_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe WasteExemptionsEngine::RegistrationExemption, type: :model do
 
   describe "#order_by_state_then_id" do
     let(:registration) do
-      registration = create(:registration)
+      registration = create(:registration, registration_exemptions: [])
       5.times do
         %i[active ceased revoked expired].each do |state|
           create(
             :registration_exemption,
             registration: registration,
-            exemption: WasteExemptionsEngine::Exemption.all.sample,
+            exemption: build(:exemption),
             state: state
           )
         end

--- a/spec/models/reports/monthly_bulk_serializer_spec.rb
+++ b/spec/models/reports/monthly_bulk_serializer_spec.rb
@@ -10,9 +10,14 @@ module Reports
 
     describe "#to_csv" do
       it "return a string in CSV format with complete exemptions details for the given month" do
-        create_list(:registration, 3)
-        # The registration factories default to creating 3 exemptions per-registration factory.
+        3.times do
+          registration_exemptions = build_list(:registration_exemption, 3)
+          create(:registration, registration_exemptions: registration_exemptions)
+        end
+
+        # Since every created registration has 3 registration exemptions, then:
         total_exemptions = 3 * 3
+
         csv_lines = monthly_bulk_serializer.to_csv.split("\n")
 
         expect(csv_lines.first).to eq(described_class::ATTRIBUTES.map(&:to_s).join(","))

--- a/spec/models/reports/monthly_bulk_serializer_spec.rb
+++ b/spec/models/reports/monthly_bulk_serializer_spec.rb
@@ -11,14 +11,12 @@ module Reports
     describe "#to_csv" do
       it "return a string in CSV format with complete exemptions details for the given month" do
         create_list(:registration, 3)
-
-        # TODO: Solve this at a factory level and deal with the cascade of fixes
-        WasteExemptionsEngine::RegistrationExemption.update_all(registered_on: Date.today)
-
+        # The registration factories default to creating 3 exemptions per-registration factory.
+        total_exemptions = 3 * 3
         csv_lines = monthly_bulk_serializer.to_csv.split("\n")
 
         expect(csv_lines.first).to eq(described_class::ATTRIBUTES.map(&:to_s).join(","))
-        expect(csv_lines.count).to eq(WasteExemptionsEngine::RegistrationExemption.count + 1)
+        expect(csv_lines.count).to eq(total_exemptions + 1)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,11 +56,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  # Seed the test DB. This ensures the exemptions table contains all of the standard exemptions.
-  config.before(:suite) do
-    Rails.application.load_seed
-  end
-
   config.before(:each) { Bullet.start_request }
   config.after(:each) { Bullet.end_request }
 end


### PR DESCRIPTION
This removes the need of seeding Exemption in the database and fixes connected specs.
Housekeeping and alignment with other services.