### PR TITLE
Update schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190610152745) do
+ActiveRecord::Schema.define(version: 20190626142528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -226,6 +226,17 @@ ActiveRecord::Schema.define(version: 20190610152745) do
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
 
+  create_table "version_archives", force: :cascade do |t|
+    t.string   "item_type",  null: false
+    t.integer  "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+  end
+
+  add_index "version_archives", ["item_type", "item_id"], name: "index_version_archives_on_item_type_and_item_id", using: :btree
+
   create_table "versions", force: :cascade do |t|
     t.string   "item_type",  null: false
     t.integer  "item_id",    null: false
@@ -233,6 +244,7 @@ ActiveRecord::Schema.define(version: 20190610152745) do
     t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
+    t.json     "json"
   end
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree


### PR DESCRIPTION
The following PR's in the engine have lead changes in the service database schema that are not reflected in this app's `schema.rb`.

- [Add versions archive table migration](https://github.com/DEFRA/waste-exemptions-engine/pull/218)
- [Store a single version of registration and its relations](https://github.com/DEFRA/waste-exemptions-engine/pull/220)

This was causing errors in our Jenkins database reset job hence this change to ensure everything is updated.