### PR TITLE
Include polyfill for old browsers support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "github_changelog_generator", require: false
 
 # GOV.UK styling
 gem "govuk_elements_rails", "~> 3.1"
-gem "govuk_template", "~> 0.23"
+gem "govuk_template", "~> 0.26"
 # Use jquery as the JavaScript library
 gem "jquery-rails"
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ DEPENDENCIES
   factory_bot_rails
   github_changelog_generator
   govuk_elements_rails (~> 3.1)
-  govuk_template (~> 0.23)
+  govuk_template (~> 0.26)
   jquery-rails
   kaminari (~> 1.1)
   paper_trail (~> 10.2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,7 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+//= require govuk/details.polyfill.js
+
+// Init polyfill code from GOVUK
+GOVUK.details.init()

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:head) do %>
   <%= stylesheet_link_tag "application", media: "all" %>
+  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
   <!--[if IE 8]><%= stylesheet_link_tag "ie8" %><![endif]-->
   <%= csrf_meta_tags %>
 <% end %>


### PR DESCRIPTION
From https://eaflood.atlassian.net/browse/RUBY-117

Includes polyfill file and javascript application and init the polyfill details JS class