### PR TITLE
 Attach logo to email instead of linking to gov.uk 

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module MailerHelper
+  # This ensures that an images we need to display in an email are shown by
+  # adding them as attachments rather than exposing them as links to the
+  # service. We have found this a more reliable method and is the same used as
+  # in WEX and FRAE
+  def email_image_tag(image, **options)
+    path = "/app/assets/images/#{image}"
+
+    full_path = Rails.root.join(path)
+
+    full_path = "#{Gem.loaded_specs['waste_exemptions_engine'].full_gem_path}#{path}" unless File.exist?(full_path)
+
+    attachments[image] = File.read(full_path)
+    image_tag(attachments[image].url, **options)
+  end
+end

--- a/app/mailers/renewal_reminder_mailer.rb
+++ b/app/mailers/renewal_reminder_mailer.rb
@@ -3,6 +3,7 @@
 class RenewalReminderMailer < ActionMailer::Base
   # So we can use displayable_address()
   include ::WasteExemptionsEngine::ApplicationHelper
+  add_template_helper(MailerHelper)
 
   def first_reminder_email(registration)
     @contact_name = contact_name(registration)

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -33,7 +33,8 @@
                                                     <table cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse">
                                                         <tbody>
                                                             <tr>
-                                                                <td style="padding-left:30px"><img src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png" alt="" style="margin-top:4px" height="32" border="0">
+                                                                <td style="padding-left:30px">
+                                                                    <%= email_image_tag("waste_exemptions_engine/govuk_logotype_email.png", { alt: "GOV.UK", style: "margin-top:4px", height: "32", border: "0" }) %>
                                                                 </td>
                                                                 <td style="font-size:28px; line-height:1.315789474; margin-top:4px; padding-left:10px">
                                                                     <span style="font-family:Helvetica,Arial,sans-serif; font-weight:700; color:#ffffff; text-decoration:none; vertical-align:top; display:inline-block">GOV.UK</span>

--- a/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
+++ b/app/views/renewal_reminder_mailer/first_reminder_email.html.erb
@@ -36,9 +36,6 @@
                                                                 <td style="padding-left:30px">
                                                                     <%= email_image_tag("waste_exemptions_engine/govuk_logotype_email.png", { alt: "GOV.UK", style: "margin-top:4px", height: "32", border: "0" }) %>
                                                                 </td>
-                                                                <td style="font-size:28px; line-height:1.315789474; margin-top:4px; padding-left:10px">
-                                                                    <span style="font-family:Helvetica,Arial,sans-serif; font-weight:700; color:#ffffff; text-decoration:none; vertical-align:top; display:inline-block">GOV.UK</span>
-                                                                </td>
                                                             </tr>
                                                         </tbody>
                                                     </table>

--- a/spec/mailers/renewal_mailer_spec.rb
+++ b/spec/mailers/renewal_mailer_spec.rb
@@ -26,27 +26,27 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
     end
 
     it "includes the correct template in the body" do
-      expect(mail.body.encoded).to include("Until our online renewal service is launched, you’ll need to register your exemptions again.")
+      expect(mail.body.parts[0].body.encoded).to include("Until our online renewal service is launched, you’ll need to register your exemptions again.")
     end
 
     it "includes the correct contact name" do
       contact_name = "#{registration.contact_first_name} #{registration.contact_last_name}"
-      expect(mail.body.encoded).to include(contact_name)
+      expect(mail.body.parts[0].body.encoded).to include(contact_name)
     end
 
     it "includes the correct expiry date" do
       expires_on = registration.registration_exemptions.first.expires_on.to_formatted_s(:day_month_year)
-      expect(mail.body.encoded).to include(expires_on)
+      expect(mail.body.parts[0].body.encoded).to include(expires_on)
     end
 
     it "includes the correct reference" do
       reference = registration.reference
-      expect(mail.body.encoded).to include(reference)
+      expect(mail.body.parts[0].body.encoded).to include(reference)
     end
 
     it "includes the correct grid reference" do
       grid_reference = registration.site_address.grid_reference
-      expect(mail.body.encoded).to include(grid_reference)
+      expect(mail.body.parts[0].body.encoded).to include(grid_reference)
     end
 
     context "when the site address is an address" do
@@ -55,21 +55,21 @@ RSpec.describe RenewalReminderMailer, type: :mailer do
       it "includes the correct address" do
         address = registration.site_address
         address_text = "#{address.premises}, #{address.street_address}, #{address.locality}, #{address.city}, #{address.postcode}"
-        expect(mail.body.encoded).to include(address_text)
+        expect(mail.body.parts[0].body.encoded).to include(address_text)
       end
     end
 
     it "includes active exemptions" do
       re = registration.registration_exemptions.first
       exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
-      expect(mail.body.encoded).to include(exemption_text)
+      expect(mail.body.parts[0].body.encoded).to include(exemption_text)
     end
 
     it "excludes inactive exemptions" do
       re = registration.registration_exemptions.last
       re.state = :ceased
       exemption_text = "#{re.exemption.code} #{re.exemption.summary}"
-      expect(mail.body.encoded).to_not include(exemption_text)
+      expect(mail.body.parts[0].body.encoded).to_not include(exemption_text)
     end
   end
 end


### PR DESCRIPTION
From: https://eaflood.atlassian.net/browse/RUBY-252

Attach logo to email as per WCR instead of linking to Gov.uk