### PR TITLE
Update privacy policy

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,22 +1,94 @@
 <% content_for :title, "Privacy policy" %>
 
 <div class="text">
-  <h1 class="heading-large">Privacy policy</h1>
-  <p>The waste exemptions service is run by the Environment Agency. Information you provide is handled in accordance with its <a rel="external" href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter">personal information charter.</a></p>
-  <p>The personal information you provide will be used to update the public register for exempt waste operations.</p>
-  <p>This will include:</p>
+  <h1 class="heading-large">
+    Privacy Policy: how we use your personal information
+  </h1>
+  <p>
+    We are the Environment Agency and we run the Register Your Waste Exemptions service. We are the
+    data controller for this service. A data controller determines how and why personal data
+    (personal information) is processed.
+  </p>
+  <p>
+    Our <a rel="external" href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter">personal information charter</a>
+    explains your rights and how we deal with your personal information. You can access the charter
+    using the link or go to GOV.UK and search 'Environment Agency personal information charter’.
+  </p>
+
+  <h2 class="heading-medium">The personal data we need</h2>
+  <p>The personal data we collect about you includes:</p>
   <ul class="list list-bullet">
     <li>the name and address of your business or organisation</li>
+    <li>contact details</li>
     <li>the type of exempt waste operations being carried out</li>
     <li>the locations of these operations</li>
   </ul>
-  <p>We may also use the personal information you give us to:</p>
-  <ul class="list list-bullet">
-    <li>contact you about our customer service</li>
-    <li>send you environmental information, or consult you on environmental issues</li>
-    <li>carry out research on environmental issues</li>
-    <li>prevent someone from breaking environmental laws, or investigate and take action when someone may have broken environmental laws</li>
-    <li>respond to freedom of information requests (if data protection law allows it)</li>
-  </ul>
-  <p>We may pass on your personal information to our agents or representatives so that they can do any of these things on our behalf. And we may share your personal information with other organisations if the law says we have to do so.</p>
+  <p>
+    We are allowed to process your personal data because we have official authority to register
+    waste exemptions. The lawful basis for processing your personal data is to exercise our official authority that is
+    set out in law.
+  </p>
+
+  <h2 class="heading-medium">
+    What we do with your personal data
+  </h2>
+  <p>
+    We use your personal data in order to process your registration.
+    If you do not provide the information requested, we cannot register your waste exemptions.
+  </p>
+  <p>
+    We put some of the information from your registration on a public register. This will include
+    the name and address of your business, the type of exempt waste operations being carried out,
+    and the locations of these operations. We will not share or disclose any further personal data
+    to any other party outside the Environment Agency without your explicit consent, unless lawfully
+    able to do so.
+  </p>
+  <p>
+    We store and process your personal data on our servers within the European Economic Area (EEA).
+  </p>
+  <p>
+    We do not use your personal data to make an automated decision or for automated profiling.
+  </p>
+
+  <h2 class="heading-medium">
+    How long we keep your personal data
+  </h2>
+  <p>
+    We will keep your personal data for 7 years after a registration has ended.
+  </p>
+
+  <h2 class="heading-medium">
+    Contact details
+  </h2>
+  <p>
+    Our Data Protection Officer (DPO) is responsible for independent advice and monitoring of the
+    Environment Agency’s use of personal information.
+  </p>
+  <p>
+    If you have any concerns or queries about how we process personal data, or if you would like to
+    make a complaint or request relating to data protection, please contact:
+  </p>
+  <p>
+    Data Protection Officer<br />
+    Environment Agency<br />
+    Horizon House<br />
+    Deanery Road<br />
+    Bristol<br />
+    BS1 5AH
+  </p>
+  <p>
+    Email: <a rel="external" href="mailto:dataprotection@environment-agency.gov.uk">dataprotection@environment-agency.gov.uk</a>
+  <p>
+  <p>
+    The Information Commissioner's Office (ICO) is the supervisory authority for data protection
+    legislation. The <a rel="external" href="https://ico.org.uk/your-data-matters">ICO website</a>
+    has a full list of your rights under data protection legislation.
+  </p>
+  <p>
+    You have the right to <a rel="external" href="https://ico.org.uk/make-a-complaint">lodge a complaint with the ICO</a>
+    at any time.
+  </p>
+  <div class="app-c-published-dates">
+    This notice was last updated on 11 July 2019.
+  </div>
 </div>


### PR DESCRIPTION
For whatever reason, the version of the privacy policy in the back office has not been updated inline with the version in the front office. So prior to this change it was still the old version prior to our GDPR review.

It's possibly the fact the link to the privacy policy in the footer does not exist in the back office, and hence it was overlooked. However with the new verbal privacy policy we do have a link, but without this change users will see the old content.

This change updates it to bring it inline with the front office, with GDPR reviewed content.