### PR TITLE
Use id instead of reference when dealing with in progress registrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "paper_trail", "~> 10.2.0"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "registration-reference"
+    branch: "master"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
 gem "defra_ruby_aws",

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "paper_trail", "~> 10.2.0"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "master"
+    branch: "registration-reference"
 
 # Use the Defra Ruby Aws gem for loading files to AWS buckets
 gem "defra_ruby_aws",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: b84eccbf64a709b555ea1c45b8e2ff8ef0b04f90
-  branch: registration-reference
+  revision: 7a60ed5b41037433e483700b163307b6324074a9
+  branch: master
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 9c8a81e3b0c65ef7b337d9b411e496320853d167
-  branch: master
+  revision: b84eccbf64a709b555ea1c45b8e2ff8ef0b04f90
+  branch: registration-reference
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)

--- a/app/helpers/action_links_helper.rb
+++ b/app/helpers/action_links_helper.rb
@@ -5,7 +5,7 @@ module ActionLinksHelper
     if resource.is_a?(WasteExemptionsEngine::Registration)
       registration_path(resource.reference)
     elsif resource.is_a?(WasteExemptionsEngine::NewRegistration)
-      new_registration_path(resource.reference)
+      new_registration_path(resource.id)
     else
       "#"
     end

--- a/app/views/new_registrations/show.html.erb
+++ b/app/views/new_registrations/show.html.erb
@@ -3,7 +3,7 @@
     <%= render("waste_exemptions_engine/shared/back", back_path: root_path) %>
 
     <h1 class="heading-large">
-      <%= t(".heading", reference: @resource.reference) %>
+      <%= t(".heading") %>
     </h1>
   </div>
 </div>

--- a/config/locales/new_registrations.en.yml
+++ b/config/locales/new_registrations.en.yml
@@ -2,4 +2,4 @@ en:
   new_registrations:
     show:
       title: "In-progress registration details"
-      heading: "In-progress registration details for %{reference}"
+      heading: "In-progress registration details"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   # Registration management
 
   resources :registrations, only: :show, param: :reference
-  resources :new_registrations, only: :show, param: :reference, path: "/new-registrations"
+  resources :new_registrations, only: :show, path: "/new-registrations"
 
   # Deregister Registrations
 

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -30,10 +30,6 @@ FactoryBot.define do
       "Operator #{n}"
     end
 
-    sequence :reference do |n|
-      "WEX#{n}"
-    end
-
     transient_addresses do
       [build(:transient_address, :operator),
        build(:transient_address, :contact),

--- a/spec/helpers/action_links_helper_spec.rb
+++ b/spec/helpers/action_links_helper_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActionLinksHelper, type: :helper do
       let(:resource) { create(:new_registration) }
 
       it "returns the correct path" do
-        expect(helper.view_link_for(resource)).to eq(new_registration_path(resource.reference))
+        expect(helper.view_link_for(resource)).to eq(new_registration_path(resource.id))
       end
     end
 

--- a/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
+++ b/spec/presenters/reports/exemption_epr_report_presenter_spec.rb
@@ -17,10 +17,10 @@ module Reports
     subject(:presenter) { described_class.new(registration_exemption) }
 
     describe "#registration_number" do
-      let(:registration) { create(:registration, reference: "WEX00123") }
+      let(:registration) { create(:registration) }
 
       it "returns the registration reference" do
-        expect(presenter.registration_number).to eq("WEX00123")
+        expect(presenter.registration_number).to eq(registration.reference)
       end
     end
 

--- a/spec/requests/new_registrations_spec.rb
+++ b/spec/requests/new_registrations_spec.rb
@@ -5,20 +5,15 @@ require "rails_helper"
 RSpec.describe "NewRegistrations", type: :request do
   let(:new_registration) { create(:new_registration) }
 
-  describe "GET /new-registrations/:reference" do
+  describe "GET /new-registrations/:id" do
     context "when a user is signed in" do
       before(:each) do
         sign_in(create(:user))
       end
 
       it "renders the show template" do
-        get "/new-registrations/#{new_registration.reference}"
+        get "/new-registrations/#{new_registration.id}"
         expect(response).to render_template(:show)
-      end
-
-      it "includes the correct reference" do
-        get "/new-registrations/#{new_registration.reference}"
-        expect(response.body).to include(new_registration.reference)
       end
     end
 
@@ -26,7 +21,7 @@ RSpec.describe "NewRegistrations", type: :request do
       before { sign_out(create(:user)) }
 
       it "redirects to the sign-in page" do
-        get "/new-registrations/#{new_registration.reference}"
+        get "/new-registrations/#{new_registration.id}"
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe SearchService do
 
     context "when the model is set to new_registrations" do
       let(:model) { :new_registrations }
-      let(:term) { new_registration.reference }
+      let(:term) { new_registration.applicant_first_name }
 
       it "should return matching new_registrations" do
         expect(results).to include(new_registration)


### PR DESCRIPTION
Since in progress registrations will not have any more a reference number, we will have to use the ID instead. Hence this updates the rules of the route and removes the reference number from the heading of the show view. 

<img width="954" alt="Screenshot 2019-07-10 at 15 14 49" src="https://user-images.githubusercontent.com/1385397/60976400-8612b080-a325-11e9-9e3c-16831f0bca15.png">
<img width="1172" alt="Screenshot 2019-07-10 at 15 15 05" src="https://user-images.githubusercontent.com/1385397/60976401-8612b080-a325-11e9-81ed-04d97ffb70bb.png">
