### PR TITLE
Use id instead of reference to find the correct new registration

### DIFF
--- a/app/controllers/new_registrations_controller.rb
+++ b/app/controllers/new_registrations_controller.rb
@@ -5,14 +5,14 @@ class NewRegistrationsController < ApplicationController
   helper RegistrationsHelper
 
   def show
-    find_resource(params[:reference])
+    find_resource(params[:id])
     authorize
   end
 
   private
 
-  def find_resource(reference)
-    @resource = WasteExemptionsEngine::NewRegistration.find_by(reference: reference)
+  def find_resource(id)
+    @resource = WasteExemptionsEngine::NewRegistration.find(id)
   end
 
   def authorize


### PR DESCRIPTION
Since we updated the routes to pass through the Id instead of the reference, we also need to update the controller to use the correct parameter to fetch the resource