### PR TITLE
[RUBY-4189] Add charge breakdown cell styles and update presenter class names

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,7 @@
 .vertical-align-top {
   vertical-align: top;
 }
+
+.charge-breakdown__breakdown-cell {
+  padding-right: govuk-spacing(4);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,5 +50,5 @@
 }
 
 .charge-breakdown__breakdown-cell {
-  padding-right: govuk-spacing(4);
+  padding-right: govuk-spacing(2);
 }

--- a/app/presenters/payment_details/charge_breakdown_presenter.rb
+++ b/app/presenters/payment_details/charge_breakdown_presenter.rb
@@ -13,10 +13,16 @@ module PaymentDetails
       end
 
       def breakdown_cell_classes
-        return "charge-breakdown__breakdown-cell govuk-table__cell govuk-!-padding-top-0" if @total
-        return "charge-breakdown__breakdown-cell govuk-!-padding-top-2" if @top_padded
+        classes = ["charge-breakdown__breakdown-cell"]
 
-        "charge-breakdown__breakdown-cell"
+        if @total
+          classes << "govuk-table__cell"
+          classes << "govuk-!-padding-top-0"
+        elsif @top_padded
+          classes << "govuk-!-padding-top-2"
+        end
+
+        classes.join(" ")
       end
 
       def amount_cell_classes

--- a/app/presenters/payment_details/charge_breakdown_presenter.rb
+++ b/app/presenters/payment_details/charge_breakdown_presenter.rb
@@ -13,10 +13,10 @@ module PaymentDetails
       end
 
       def breakdown_cell_classes
-        return "govuk-table__cell govuk-!-padding-top-0" if @total
-        return "govuk-!-padding-top-2" if @top_padded
+        return "charge-breakdown__breakdown-cell govuk-table__cell govuk-!-padding-top-0" if @total
+        return "charge-breakdown__breakdown-cell govuk-!-padding-top-2" if @top_padded
 
-        nil
+        "charge-breakdown__breakdown-cell"
       end
 
       def amount_cell_classes

--- a/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
+++ b/spec/presenters/payment_details/charge_breakdown_presenter_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe PaymentDetails::ChargeBreakdownPresenter do
     end
 
     it "exposes presentational cell classes on each row" do
-      expect(rows.first.breakdown_cell_classes).to eq("govuk-!-padding-top-2")
+      expect(rows.first.breakdown_cell_classes).to eq("charge-breakdown__breakdown-cell govuk-!-padding-top-2")
       expect(rows.first.amount_cell_classes).to eq("govuk-!-text-align-right govuk-!-padding-top-2 vertical-align-top")
-      expect(rows.last.breakdown_cell_classes).to eq("govuk-table__cell govuk-!-padding-top-0")
+      expect(rows.last.breakdown_cell_classes).to eq("charge-breakdown__breakdown-cell govuk-table__cell govuk-!-padding-top-0")
       expect(rows.last.amount_cell_classes).to eq("govuk-table__cell govuk-!-text-align-right govuk-!-padding-top-0")
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-4229
Adjust spacing between charge breakdown and amount

<img width="701" height="467" alt="image" src="https://github.com/user-attachments/assets/4130a569-c670-48c8-88f2-c8a6e9715290" />

